### PR TITLE
Enhance EvilEyes glow on Vibe Killer page

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -57,7 +57,7 @@
 .evil-eyes {
   opacity: 0;
   animation: eyesFade 2s forwards;
-  filter: brightness(0.22) blur(2px);
+  filter: brightness(0.28) blur(2px);
   transform: scale(0.7);
 }
 
@@ -72,8 +72,8 @@
   position: absolute;
   inset: 0;
   background: radial-gradient(circle at 50% 50%, rgba(220,20,20,0.6) 35%, rgba(150,0,0,0.25) 60%, transparent 80%);
-  filter: blur(10px) drop-shadow(0 0 27.5px rgba(255,0,0,0.6))
-    drop-shadow(0 0 60.5px rgba(255,0,0,0.3)) saturate(1);
+  filter: blur(10px) drop-shadow(0 0 35px rgba(255,0,0,0.6))
+    drop-shadow(0 0 70px rgba(255,0,0,0.3)) saturate(1.2);
   animation: blink 5s infinite;
 }
 
@@ -112,7 +112,7 @@
 
 @keyframes eyesFade {
   to {
-    opacity: 0.385;
+    opacity: 0.45;
   }
 }
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -57,7 +57,7 @@
 .evil-eyes {
   opacity: 0;
   animation: eyesFade 2s forwards;
-  filter: brightness(0.2) blur(2px);
+  filter: brightness(0.22) blur(2px);
   transform: scale(0.7);
 }
 
@@ -72,8 +72,8 @@
   position: absolute;
   inset: 0;
   background: radial-gradient(circle at 50% 50%, rgba(220,20,20,0.6) 35%, rgba(150,0,0,0.25) 60%, transparent 80%);
-  filter: blur(10px) drop-shadow(0 0 25px rgba(255,0,0,0.6))
-    drop-shadow(0 0 55px rgba(255,0,0,0.3)) saturate(0.9);
+  filter: blur(10px) drop-shadow(0 0 27.5px rgba(255,0,0,0.6))
+    drop-shadow(0 0 60.5px rgba(255,0,0,0.3)) saturate(1);
   animation: blink 5s infinite;
 }
 
@@ -112,7 +112,7 @@
 
 @keyframes eyesFade {
   to {
-    opacity: 0.35;
+    opacity: 0.385;
   }
 }
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -57,7 +57,7 @@
 .evil-eyes {
   opacity: 0;
   animation: eyesFade 2s forwards;
-  filter: brightness(0.28) blur(2px);
+  filter: brightness(0.31) blur(2px);
   transform: scale(0.7);
 }
 
@@ -72,8 +72,8 @@
   position: absolute;
   inset: 0;
   background: radial-gradient(circle at 50% 50%, rgba(220,20,20,0.6) 35%, rgba(150,0,0,0.25) 60%, transparent 80%);
-  filter: blur(10px) drop-shadow(0 0 35px rgba(255,0,0,0.6))
-    drop-shadow(0 0 70px rgba(255,0,0,0.3)) saturate(1.2);
+  filter: blur(10px) drop-shadow(0 0 39px rgba(255,0,0,0.6))
+    drop-shadow(0 0 77px rgba(255,0,0,0.3)) saturate(1.32);
   animation: blink 5s infinite;
 }
 
@@ -112,7 +112,7 @@
 
 @keyframes eyesFade {
   to {
-    opacity: 0.45;
+    opacity: 0.5;
   }
 }
 


### PR DESCRIPTION
## Summary
- brighten EvilEyes component with 10% higher brightness and stronger drop-shadows
- raise final eyesFade opacity for more visible eyes

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aad84ea9a083229250dbda428ac9db