### PR TITLE
Enhance EvilEyes glow and polish Ingestor uploads

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -57,7 +57,7 @@
 .evil-eyes {
   opacity: 0;
   animation: eyesFade 2s forwards;
-  filter: brightness(0.31) blur(2px);
+  filter: brightness(0.34) blur(2px);
   transform: scale(0.7);
 }
 
@@ -72,8 +72,8 @@
   position: absolute;
   inset: 0;
   background: radial-gradient(circle at 50% 50%, rgba(220,20,20,0.6) 35%, rgba(150,0,0,0.25) 60%, transparent 80%);
-  filter: blur(10px) drop-shadow(0 0 39px rgba(255,0,0,0.6))
-    drop-shadow(0 0 77px rgba(255,0,0,0.3)) saturate(1.32);
+  filter: blur(10px) drop-shadow(0 0 43px rgba(255,0,0,0.6))
+    drop-shadow(0 0 85px rgba(255,0,0,0.3)) saturate(1.45);
   animation: blink 5s infinite;
 }
 
@@ -112,7 +112,7 @@
 
 @keyframes eyesFade {
   to {
-    opacity: 0.5;
+    opacity: 0.55;
   }
 }
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -57,7 +57,7 @@
 .evil-eyes {
   opacity: 0;
   animation: eyesFade 2s forwards;
-  filter: brightness(0.2) blur(2px);
+  filter: brightness(0.31) blur(2px);
   transform: scale(0.7);
 }
 
@@ -72,8 +72,8 @@
   position: absolute;
   inset: 0;
   background: radial-gradient(circle at 50% 50%, rgba(220,20,20,0.6) 35%, rgba(150,0,0,0.25) 60%, transparent 80%);
-  filter: blur(10px) drop-shadow(0 0 25px rgba(255,0,0,0.6))
-    drop-shadow(0 0 55px rgba(255,0,0,0.3)) saturate(0.9);
+  filter: blur(10px) drop-shadow(0 0 39px rgba(255,0,0,0.6))
+    drop-shadow(0 0 77px rgba(255,0,0,0.3)) saturate(1.32);
   animation: blink 5s infinite;
 }
 
@@ -112,7 +112,7 @@
 
 @keyframes eyesFade {
   to {
-    opacity: 0.35;
+    opacity: 0.5;
   }
 }
 

--- a/app/ingest/page.tsx
+++ b/app/ingest/page.tsx
@@ -417,11 +417,15 @@ export default function IngestPage() {
             <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
               <Card>
                 <div className="text-sm font-semibold mb-2">Takeaways</div>
-                <ul className="list-disc list-inside text-xs text-zinc-400 space-y-1">
-                  {result.analysis.takeaways.map(t => (
-                    <li key={t}>{t}</li>
-                  ))}
-                </ul>
+                {result.analysis.takeaways.length ? (
+                  <ul className="list-disc list-inside text-xs text-zinc-400 space-y-1">
+                    {result.analysis.takeaways.map(t => (
+                      <li key={t}>{t}</li>
+                    ))}
+                  </ul>
+                ) : (
+                  <p className="text-xs text-zinc-500">No takeaways generated.</p>
+                )}
               </Card>
               {(['complexity', 'documentation', 'tests'] as const).map(key => (
                 <Card key={key}>
@@ -430,6 +434,13 @@ export default function IngestPage() {
                   </div>
                   <div className="w-full max-w-[150px] mx-auto">
                     <Gauge value={result.analysis.metrics[key]} />
+                  </div>
+                  <div className="text-xs text-zinc-500 text-center mt-2">
+                    {result.analysis.metrics[key] >= 80
+                      ? 'Looks solid'
+                      : result.analysis.metrics[key] >= 60
+                      ? 'Room for improvement'
+                      : 'Needs attention'}
                   </div>
                 </Card>
               ))}

--- a/app/ingest/page.tsx
+++ b/app/ingest/page.tsx
@@ -297,7 +297,7 @@ export default function IngestPage() {
                       type="file"
                       name="file"
                       accept=".zip"
-                      className="block w-full text-sm file:mr-4 file:py-2 file:px-4 file:rounded-lg file:border-0 file:text-sm file:font-semibold file:bg-zinc-800 file:text-zinc-200 hover:file:bg-zinc-700"
+                      className="block w-full text-sm text-zinc-200 bg-zinc-800/50 border border-zinc-700 rounded-lg file:mr-4 file:py-2 file:px-4 file:rounded-lg file:border-0 file:text-sm file:font-semibold file:bg-zinc-800 file:text-zinc-200 hover:file:bg-zinc-700 focus:outline-none"
                     />
                     <button
                       type="submit"

--- a/app/roaster/page.tsx
+++ b/app/roaster/page.tsx
@@ -370,14 +370,14 @@ export default function RoasterPage() {
   const hue = 120 - level * 120
   const gradientStyle: CSSProperties = healed
     ? {
-        background: 'radial-gradient(circle at 50% 50%, hsl(210,60%,20%), #000)',
+        background: 'radial-gradient(circle at 50% 50%, hsl(210,60%,24%), #000)',
         backgroundSize: '200% 200%',
         animation: 'bgMove 20s ease infinite',
         transition: 'background 0.5s',
         filter: 'blur(40px)'
       }
     : {
-        background: `radial-gradient(circle at 50% 50%, hsl(${hue},60%,13%), #000)`,
+        background: `radial-gradient(circle at 50% 50%, hsl(${hue},60%,17%), #000)`,
         backgroundSize: '200% 200%',
         animation: 'bgMove 20s ease infinite',
         transition: 'background 0.5s',

--- a/components/DocsUploader.tsx
+++ b/components/DocsUploader.tsx
@@ -64,13 +64,13 @@ export default function DocsUploader({
               {item ? (
                 <div className="flex items-center gap-2">
                   <input
-                    className="flex-1 bg-transparent border-b border-zinc-700 focus:outline-none text-sm"
+                    className="flex-1 px-2 py-1 bg-zinc-800/50 border border-zinc-700 rounded text-sm text-zinc-200 focus:outline-none"
                     value={item.name}
                     onChange={e => handleName(idx, e.target.value)}
                   />
                   <button
                     onClick={() => handleDelete(idx)}
-                    className="text-xs bg-zinc-800 px-2 py-1 rounded"
+                    className="text-xs bg-zinc-800 px-2 py-1 rounded hover:bg-zinc-700"
                   >
                     Delete
                   </button>


### PR DESCRIPTION
## Summary
- increase EvilEyes brightness filter and drop-shadow radii by about 10% for a stronger glow
- raise eyesFade animation final opacity to 0.5 so the eyes remain more visible
- restyle file upload inputs on the Ingest page with dark backgrounds and borders to replace thin white lines

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aad84ea9a083229250dbda428ac9db