### PR TITLE
feat: support openai models

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ OINT stands for Onvoarding Insights Neural Toolset.
 - **Integration Matrix** &mdash; Inspect package dependencies and readiness at `/matrix`.
 - **3D Commit Map** &mdash; Explore commit relationships in an interactive three.js scene at `/3d-map`.
 - **GitHub App Integration** &mdash; Authorize a GitHub App to analyze private repositories.
-- **AI‑Powered Analysis** &mdash; Summaries, roast comments, and AI artifact detection using `AIML_API_KEY` or `OPENAI_API_KEY`.
+- **AI‑Powered Analysis** &mdash; Summaries, roast comments, and AI artifact detection using `AIML_API_KEY` or `OPENAI_API_KEY`. Supports OpenAI's latest `gpt-4o` and `gpt-5-nano` models when an `OPENAI_API_KEY` is provided.
 
 ## Tech Stack
 
@@ -43,7 +43,7 @@ AIML_API_KEY=your_aiml_api_key          # or OPENAI_API_KEY
 AIML_API_BASE_URL=https://api.aimlapi.com/v1 # optional
 OPENAI_API_KEY=your_openai_key          # optional
 OPENAI_BASE_URL=https://api.openai.com/v1 # optional
-LLM_MODEL=gpt-5-chat                    # optional model override
+LLM_MODEL=gpt-4o                         # optional model override (e.g., gpt-5-nano)
 ```
 
 ### Scripts

--- a/lib/openai.ts
+++ b/lib/openai.ts
@@ -41,17 +41,17 @@ async function chat(
     ? models
     : models
     ? [models]
-    : [process.env.LLM_MODEL || 'gpt-5-chat']
-  const modelList = [...base, 'gpt-4o'].filter(
+    : [process.env.LLM_MODEL || 'gpt-4o']
+  const modelList = [...base, 'gpt-4o', 'gpt-5-nano'].filter(
     (v, i, a) => a.indexOf(v) === i
   )
   let lastErr: any
   for (let i = 0; i < modelList.length; i++) {
     const m = modelList[i]
     try {
-      const res = await client.chat.completions.create({
+      const res = await client.responses.create({
         model: m,
-        messages,
+        input: messages,
         reasoning: m.startsWith('gpt-5')
           ? (({ effort: 'medium' } as unknown) as any)
           : undefined,
@@ -60,7 +60,11 @@ async function chat(
       if (i > 0) {
         console.warn(`LLM model fallback: using ${m} after ${modelList[i - 1]} failed`)
       }
-      return res.choices[0]?.message?.content ?? '{}'
+      return (
+        (res as any).output_text ||
+        (res as any).output?.[0]?.content?.[0]?.text ||
+        '{}'
+      )
     } catch (err) {
       console.error(`LLM model ${m} failed`, err)
       lastErr = err


### PR DESCRIPTION
## Summary
- expand LLM helper to use OpenAI Responses API with GPT-4o and GPT-5-nano support
- document usage of OpenAI models and update LLM model override example

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b176f39274832295334cc56bf54717